### PR TITLE
fix text overflow in student cards

### DIFF
--- a/yalies-web/src/components/peoplegrid.module.scss
+++ b/yalies-web/src/components/peoplegrid.module.scss
@@ -34,9 +34,13 @@
                 flex-direction: column;
                 justify-content: flex-start;
                 gap: 10px;
+				overflow: hidden;
+				text-overflow: ellipsis;
                 .name {
                     margin-top: 0px;
                     font-size: 1.17em;
+					overflow: hidden;
+					text-overflow: ellipsis;
                 }
                 .row {
 					font-size: 14px;


### PR DESCRIPTION
Long names and emails are truncated with ellipsis so all info stays within card boundaries.